### PR TITLE
#4 -  frontend criação e visualização de colunas personalizadas

### DIFF
--- a/src/pages/boards/BoardWorkspace.jsx
+++ b/src/pages/boards/BoardWorkspace.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import styles from "./styles/boardWorkspace.module.css";
 import { useNavigate } from "react-router-dom";
 import CreateBoardModal from "./CreateBoardModal";
+import CreateColumnModal from "./CreateColumnModal";
 import RenameBoardModal from "./RenameBoardModal";
 import DeleteConfirmModal from "./DeleteConfirmModal";
 import { getBoards } from "../../services/boardService";
@@ -13,7 +14,7 @@ import {
   FaPlus,
   FaEllipsisH,
   FaTrashAlt,
-  FaPen
+  FaPen,
 } from "react-icons/fa";
 import LogoIcon from "../../assets/Logo Icone.png";
 
@@ -29,6 +30,7 @@ const BoardWorkspace = () => {
   const [renameIndex, setRenameIndex] = useState(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteIndex, setDeleteIndex] = useState(null);
+  const [showCreateColumnModal, setShowCreateColumnModal] = useState(false);
 
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const navigate = useNavigate();
@@ -118,22 +120,51 @@ const BoardWorkspace = () => {
     navigate("/login");
   };
 
+  const handleCreateColumn = (columnName) => {
+    if (selectedBoardIndex !== null) {
+      const newColumn = {
+        id: Date.now(), // ID único
+        name: columnName,
+        cards: [],
+      };
+      setBoards((prevBoards) => {
+        const updatedBoards = [...prevBoards];
+        updatedBoards[selectedBoardIndex].columns.push(newColumn);
+        return updatedBoards;
+      });
+    }
+  };
+
   return (
     <div className={styles.pageContainer}>
       <header className={styles.header}>
         <div className={styles.headerLeft}>
-          <div className={`${styles.logo} ${!sidebarOpen ? styles.logoHidden : ''}`}>
-            <img src={LogoIcon} alt="TaskFlow Logo" className={styles.logoImage} />
+          <div
+            className={`${styles.logo} ${
+              !sidebarOpen ? styles.logoHidden : ""
+            }`}
+          >
+            <img
+              src={LogoIcon}
+              alt="TaskFlow Logo"
+              className={styles.logoImage}
+            />
           </div>
           <h1 className={styles.appName}>TaskFlow</h1>
         </div>
 
         <div className={styles.headerCenter}>
-          {selectedBoardIndex !== null ? boards[selectedBoardIndex]?.name : "Nenhum quadro selecionado"}
+          {selectedBoardIndex !== null
+            ? boards[selectedBoardIndex]?.name
+            : "Nenhum quadro selecionado"}
         </div>
 
         <div className={styles.headerRight}>
-          <div ref={userRef} onClick={() => setUserMenuOpen(!userMenuOpen)} style={{ cursor: "pointer" }}>
+          <div
+            ref={userRef}
+            onClick={() => setUserMenuOpen(!userMenuOpen)}
+            style={{ cursor: "pointer" }}
+          >
             <FaUserCircle size={29} color="#3a86ff" />
           </div>
 
@@ -144,7 +175,9 @@ const BoardWorkspace = () => {
                   <span className={styles.userDisplayName}>{fakeUserName}</span>
                 </div>
                 <div className={styles.menuDivider}></div>
-                <button className={styles.userMenuItem} onClick={handleLogout}>Fazer Logout</button>
+                <button className={styles.userMenuItem} onClick={handleLogout}>
+                  Fazer Logout
+                </button>
               </div>
             </MenuPortal>
           )}
@@ -152,20 +185,43 @@ const BoardWorkspace = () => {
       </header>
 
       <div className={styles.workspaceContainer}>
-        <div className={`${styles.toggleContainer} ${sidebarOpen ? styles.open : styles.closed}`}>
-          <button className={styles.toggleSidebarBtn} onClick={() => setSidebarOpen(!sidebarOpen)}>
-            {sidebarOpen ? <FaChevronLeft size={16} /> : <FaChevronRight size={16} />}
+        <div
+          className={`${styles.toggleContainer} ${
+            sidebarOpen ? styles.open : styles.closed
+          }`}
+        >
+          <button
+            className={styles.toggleSidebarBtn}
+            onClick={() => setSidebarOpen(!sidebarOpen)}
+          >
+            {sidebarOpen ? (
+              <FaChevronLeft size={16} />
+            ) : (
+              <FaChevronRight size={16} />
+            )}
           </button>
         </div>
 
-        <aside className={`${styles.sidebar} ${!sidebarOpen ? styles.sidebarClosed : ''}`}>
+        <aside
+          className={`${styles.sidebar} ${
+            !sidebarOpen ? styles.sidebarClosed : ""
+          }`}
+        >
           <h3 className={styles.sidebarTitle}>Task Workspace</h3>
           <div className={styles.sidebarSection}>
             <p className={styles.sectionLabel}>Meus Quadros</p>
             <ul className={styles.boardList}>
               {boards.map((board, index) => (
-                <li key={index} className={`${styles.boardItem} ${selectedBoardIndex === index ? styles.activeBoard : ""}`}>
-                  <div className={styles.boardContent} onClick={() => setSelectedBoardIndex(index)}>
+                <li
+                  key={index}
+                  className={`${styles.boardItem} ${
+                    selectedBoardIndex === index ? styles.activeBoard : ""
+                  }`}
+                >
+                  <div
+                    className={styles.boardContent}
+                    onClick={() => setSelectedBoardIndex(index)}
+                  >
                     <span className={styles.pinIcon}>📌</span>
                     {board.name}
                   </div>
@@ -174,16 +230,32 @@ const BoardWorkspace = () => {
                   </div>
                   {activeMenuIndex === index && (
                     <MenuPortal>
-                      <div ref={dropdownRef} className={styles.dropdownMenu} style={{ top: menuPosition.top, left: menuPosition.left, position: "fixed", zIndex: 9999 }}>
-                        <button onClick={() => handleRename(index)}><FaPen size={12} /> Renomear</button>
-                        <button onClick={() => handleDelete(index)}><FaTrashAlt size={12} /> Excluir</button>
+                      <div
+                        ref={dropdownRef}
+                        className={styles.dropdownMenu}
+                        style={{
+                          top: menuPosition.top,
+                          left: menuPosition.left,
+                          position: "fixed",
+                          zIndex: 9999,
+                        }}
+                      >
+                        <button onClick={() => handleRename(index)}>
+                          <FaPen size={12} /> Renomear
+                        </button>
+                        <button onClick={() => handleDelete(index)}>
+                          <FaTrashAlt size={12} /> Excluir
+                        </button>
                       </div>
                     </MenuPortal>
                   )}
                 </li>
               ))}
             </ul>
-            <button className={styles.addBoardBtn} onClick={() => setShowModal(true)}>
+            <button
+              className={styles.addBoardBtn}
+              onClick={() => setShowModal(true)}
+            >
               <FaPlus size={12} style={{ marginRight: "6px" }} />
               Novo Quadro
             </button>
@@ -191,40 +263,81 @@ const BoardWorkspace = () => {
         </aside>
 
         <main className={styles.mainContent}>
-  {loading ? (
-    <p>Carregando quadros...</p>
-  ) : selectedBoardIndex === null ? (
-    <h2>Selecione ou crie um quadro</h2>
-  ) : (
-    <div className={styles.boardView}>
-      <h2 className={styles.boardTitle}>
-        {boards[selectedBoardIndex]?.name}
-      </h2>
+          {loading ? (
+            <p>Carregando quadros...</p>
+          ) : selectedBoardIndex === null ? (
+            <h2>Selecione ou crie um quadro</h2>
+          ) : (
+            <div className={styles.boardView}>
+              <h2 className={styles.boardTitle}>
+                {boards[selectedBoardIndex]?.name}
+              </h2>
 
-      <div className={styles.columnsArea}>
-        {boards[selectedBoardIndex]?.columns?.length > 0 ? (
-          boards[selectedBoardIndex].columns.map((column) => (
-            <div key={column.id} className={styles.column}>
-              <h3 className={styles.columnTitle}>{column.name}</h3>
-              <div className={styles.columnContent}>
-                {/* Aqui você poderá renderizar cards depois */}
-                <span className={styles.placeholder}>Sem cartões</span>
+              <div className={styles.columnsArea}>
+                {boards[selectedBoardIndex]?.columns?.length > 0 ? (
+                  <>
+                    {boards[selectedBoardIndex].columns.map((column) => (
+                      <div key={column.id} className={styles.column}>
+                        <h3 className={styles.columnTitle}>{column.name}</h3>
+                        <div className={styles.columnContent}>
+                          {column.cards?.length > 0 ? (
+                            column.cards.map((card) => (
+                              <div key={card.id} className={styles.card}>
+                                {card.title}
+                              </div>
+                            ))
+                          ) : (
+                            <span className={styles.placeholder}>
+                              Sem cartões
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+
+                    {/* Botão fixo ao final das colunas */}
+                    <button
+                      className={styles.addColumnStyledBtn}
+                      onClick={() => setShowCreateColumnModal(true)}
+                    >
+                      <FaPlus size={10} style={{ marginRight: "6px" }} />
+                      Adicionar nova lista
+                    </button>
+                  </>
+                ) : (
+                  // Exibir área vazia com o botão centralizado
+                  <div className={styles.emptyBoard}>
+                    <p className={styles.emptyText}>
+                      Este quadro está vazio.{" "}
+                      <em>Comece criando uma coluna.</em>
+                    </p>
+                    <button
+                      className={styles.addColumnStyledBtn}
+                      onClick={() => setShowCreateColumnModal(true)}
+                    >
+                      <FaPlus size={10} style={{ marginRight: "6px" }} />
+                      Adicionar nova lista
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
-          ))
-        ) : (
-          <div className={styles.emptyBoard}>
-            Este quadro está vazio. Comece criando uma coluna.
-          </div>
-        )}
-      </div>
-    </div>
-  )}
-</main>
+          )}
+
+          {showCreateColumnModal && (
+            <CreateColumnModal
+              onClose={() => setShowCreateColumnModal(false)}
+              onCreate={handleCreateColumn}
+            />
+          )}
+        </main>
       </div>
 
       {showModal && (
-        <CreateBoardModal onClose={() => setShowModal(false)} onCreate={handleCreateBoard} />
+        <CreateBoardModal
+          onClose={() => setShowModal(false)}
+          onCreate={handleCreateBoard}
+        />
       )}
 
       {showRenameModal && renameIndex !== null && (
@@ -243,6 +356,13 @@ const BoardWorkspace = () => {
           boardName={boards[deleteIndex]?.name}
           onCancel={() => setShowDeleteModal(false)}
           onConfirm={confirmDeleteBoard}
+        />
+      )}
+
+      {showCreateColumnModal && (
+        <CreateColumnModal
+          onClose={() => setShowCreateColumnModal(false)}
+          onCreate={handleCreateColumn}
         />
       )}
     </div>

--- a/src/pages/boards/CreateBoardModal.jsx
+++ b/src/pages/boards/CreateBoardModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import styles from "./styles/createBoardModal.module.css";
 
 const CreateBoardModal = ({ onClose, onCreate }) => {
@@ -7,21 +7,14 @@ const CreateBoardModal = ({ onClose, onCreate }) => {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!name.trim()) return;
-
-    onCreate({ name: name.trim() });
+  
+    // Criar o novo quadro com colunas vazias
+    onCreate({ 
+      name: name.trim(),
+      columns: [] // Adicionando uma lista de colunas vazias para o quadro
+    });
     onClose(); // Fecha após criar
   };
-
-  // 🔑 Suporte à tecla ESC
-  useEffect(() => {
-    const handleKeyDown = (e) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
 
   return (
     <div className={styles.modalOverlay}>

--- a/src/pages/boards/CreateColumnModal.jsx
+++ b/src/pages/boards/CreateColumnModal.jsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import styles from "./styles/createColumnModal.module.css";
+
+const CreateColumnModal = ({ onClose, onCreate }) => {
+  const [columnName, setColumnName] = useState("");
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (columnName.trim()) {
+      onCreate(columnName.trim());
+      setColumnName("");
+      onClose();
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay}>
+      <div className={styles.modalContent}>
+        <h3 className={styles.modalTitle}>Nova Coluna</h3>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <label htmlFor="columnName" className={styles.label}>
+            Nome da Coluna
+          </label>
+          <input
+            type="text"
+            id="columnName"
+            value={columnName}
+            onChange={(e) => setColumnName(e.target.value)}
+            placeholder="Digite o nome da coluna"
+          />
+          <div className={styles.buttonGroup}>
+            <button type="submit">Adicionar</button>
+            <button
+              type="button"
+              onClick={onClose}
+              className={styles.cancelBtn}
+            >
+              Cancelar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default CreateColumnModal;

--- a/src/pages/boards/DeleteColumnConfirmModal.jsx
+++ b/src/pages/boards/DeleteColumnConfirmModal.jsx
@@ -1,0 +1,24 @@
+import styles from "./styles/deleteConfirmModal.module.css";
+
+const DeleteColumnConfirmModal = ({ columnName, onCancel, onConfirm }) => {
+  return (
+    <div className={styles.modalOverlay}>
+      <div className={styles.modal}>
+        <h2>Excluir Coluna</h2>
+        <p>
+          Você tem certeza que deseja excluir <strong>{columnName}</strong>?
+        </p>
+        <div className={styles.actions}>
+          <button className={styles.cancelBtn} onClick={onCancel}>
+            Cancelar
+          </button>
+          <button className={styles.confirmBtn} onClick={onConfirm}>
+            Excluir
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeleteColumnConfirmModal;

--- a/src/pages/boards/EmptyBoards.jsx
+++ b/src/pages/boards/EmptyBoards.jsx
@@ -1,0 +1,17 @@
+import styles from "./styles/emptyBoards.module.css";
+import { FaRegFolderOpen } from "react-icons/fa";
+
+const EmptyBoards = ({ onCreateBoard }) => {
+  return (
+    <div className={styles.emptyContainer}>
+      <FaRegFolderOpen className={styles.icon} />
+      <h2>Nenhum quadro encontrado</h2>
+      <p>Crie um quadro para começar a organizar suas tarefas.</p>
+      <button className={styles.createBtn} onClick={onCreateBoard}>
+        + Criar novo quadro
+      </button>
+    </div>
+  );
+};
+
+export default EmptyBoards;

--- a/src/pages/boards/RenameColumnModal.jsx
+++ b/src/pages/boards/RenameColumnModal.jsx
@@ -1,0 +1,35 @@
+import { useState, useEffect } from "react";
+import styles from "./styles/renameBoardModal.module.css"; // Pode reutilizar
+
+const RenameColumnModal = ({ currentName, onClose, onConfirm }) => {
+  const [name, setName] = useState(currentName);
+
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === "Enter") onConfirm(name.trim());
+      else if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [name]);
+
+  return (
+    <div className={styles.modalOverlay}>
+      <div className={styles.modal}>
+        <h2>Renomear Coluna</h2>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Novo nome"
+          autoFocus
+        />
+        <div className={styles.actions}>
+          <button onClick={onClose} className={styles.cancelBtn}>Cancelar</button>
+          <button onClick={() => onConfirm(name.trim())} className={styles.confirmBtn}>Salvar</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RenameColumnModal;

--- a/src/pages/boards/styles/boardWorkspace.module.css
+++ b/src/pages/boards/styles/boardWorkspace.module.css
@@ -501,3 +501,64 @@
   font-style: italic;
   gap: 1.5rem;
 }
+
+.columnHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+}
+
+.columnMenuIcon {
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px;
+  border-radius: 4px;
+  color: #333;
+  transition: background 0.2s ease;
+}
+
+.columnMenuIcon:hover {
+  background-color: #e0e0e0;
+}
+
+
+.dropdownMenu {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 6px 0;
+  width: 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  animation: fadeIn 0.2s ease-in-out;
+}
+
+.dropdownMenu button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #333;
+  transition: background 0.2s ease;
+}
+
+.dropdownMenu button:hover {
+  background-color: #f1f1f1;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/src/pages/boards/styles/boardWorkspace.module.css
+++ b/src/pages/boards/styles/boardWorkspace.module.css
@@ -347,15 +347,28 @@
 }
 
 .emptyBoard {
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* Centraliza horizontalmente */
+  justify-content: center; /* Centraliza verticalmente */
   background-color: #f0f4ff;
   padding: 2rem;
-  border: 1px dashed #a5b4fc;
   border-radius: 10px;
+  border: 1px dashed #a5b4fc;
   text-align: center;
+  width: 100%;
+  max-width: 500px;
+  margin: 0 auto;
   color: #666;
   font-style: italic;
-  margin: 0 auto;
-  width: 100%;
+  gap: 1.5rem;
+  min-height: 200px; /* Garante espaço para centralizar o botão */
+}
+
+.emptyText {
+  margin-bottom: 20px;
+  color: #666;
+  font-style: italic;
 }
 
 .column {
@@ -380,7 +393,7 @@
   background: #fff;
   border-radius: 6px;
   padding: 0.75rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   min-height: 60px;
 }
 
@@ -388,4 +401,103 @@
   font-size: 0.85rem;
   color: #999;
   text-align: center;
+}
+
+.card {
+  background-color: #ffffff;
+  border-radius: 6px;
+  padding: 0.8rem;
+  margin-bottom: 0.75rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #333;
+  cursor: grab;
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.cardTitle {
+  margin: 0;
+}
+
+.addColumnBtn {
+  background-color: rgba(255, 255, 255, 0.5);
+  border: 1px dashed #a5a5a5;
+  color: #333;
+  padding: 10px 14px;
+  font-size: 0.9rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.addColumnBtn:hover {
+  background-color: #ffffff;
+  border-color: #999;
+}
+
+.addColumnStyledBtn {
+  background-color: #f4f5f7;
+  color: #333;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 16px;
+  min-width: 273px;
+  max-width: 260px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  gap: 8px;
+}
+
+.addColumnStyledBtn::before {
+  font-size: 1.1rem;
+  font-weight: bold;
+  display: inline-block;
+  transform: translateY(1px);
+  /* Ajuste fino vertical */
+  color: #666;
+}
+
+.addColumnStyledBtn:hover {
+  background-color: #e3e5e8;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  transform: translateY(-1px);
+}
+
+.addColumnStyledBtn:active {
+  background-color: #d0d3d6;
+  transform: scale(0.98);
+}
+
+.emptyBoardFull {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: #f0f4ff;
+  padding: 3rem;
+  border-radius: 10px;
+  border: 1px dashed #a5b4fc;
+  text-align: center;
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+  color: #666;
+  font-style: italic;
+  gap: 1.5rem;
 }

--- a/src/pages/boards/styles/createColumnModal.module.css
+++ b/src/pages/boards/styles/createColumnModal.module.css
@@ -1,0 +1,82 @@
+.modalOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 999;
+  }
+
+.modalContent {
+    background: #fff;
+    padding: 2rem;
+    border-radius: 10px;
+    width: 400px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+  }
+  
+  .modalTitle {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: #2e2e2e;
+    text-align: center;
+    margin-top: -0.5rem; /* Opcional: deixa o título mais no topo do modal */
+    margin-bottom: 1.5rem; /* Mais espaço para o label/input */
+  }
+  
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+  
+  .label {
+    font-weight: 600;
+    color: #333;
+    font-size: 0.95rem;
+  }
+  
+  input {
+    padding: 0.7rem;
+    border-radius: 8px;
+    border: 1.5px solid #111;
+    font-size: 1rem;
+  }
+  
+  .buttonGroup {
+    display: flex;
+    justify-content: flex-start;
+    gap: 0.8rem;
+    margin-top: 0.5rem;
+  }
+  
+  button {
+    padding: 0.7rem 1.3rem;
+    font-weight: 600;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    background-color: #3a86ff;
+    color: white;
+  }
+  
+  .cancelBtn {
+    background-color: #e0e0e0;
+    color: #333;
+  }
+  
+  .cancelBtn:hover {
+    background-color: #ccc;
+  }
+  
+  button:hover {
+    background-color: #2563eb;
+  }
+  

--- a/src/pages/boards/styles/emptyBoards.module.css
+++ b/src/pages/boards/styles/emptyBoards.module.css
@@ -1,0 +1,45 @@
+.emptyContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    padding: 2rem;
+    text-align: center;
+    color: #555;
+  }
+  
+  .icon {
+    font-size: 3.5rem;
+    margin-bottom: 1rem;
+    color: #3a86ff;
+  }
+  
+  h2 {
+    font-size: 1.6rem;
+    margin-bottom: 0.5rem;
+    color: #222;
+  }
+  
+  p {
+    font-size: 1rem;
+    margin-bottom: 1rem;
+    max-width: 320px;
+  }
+  
+  .createBtn {
+    background-color: #3a86ff;
+    color: white;
+    padding: 0.6rem 1.2rem;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+  }
+  
+  .createBtn:hover {
+    background-color: #2f6fe3;
+  }
+  

--- a/src/services/boardService.js
+++ b/src/services/boardService.js
@@ -1,17 +1,29 @@
-// src/services/boardService.js
-
 export async function getBoards() {
-    return [
-      {
-        id: 1,
-        name: "Meu Quadro",
-        userId: 1,
-        columns: [
-          { id: 1, name: "A Fazer", cards: [] },
-          { id: 2, name: "Em Andamento", cards: [] },
-          { id: 3, name: "Concluído", cards: [] }
-        ]
-      }
-    ];
-  }
-  
+  return [
+    {
+      id: 1,
+      name: "Meu Quadro",
+      userId: 1,
+      columns: [
+        {
+          id: 1,
+          name: "A Fazer",
+          cards: [
+            { id: 1, title: "Estudar backlog" },
+            { id: 2, title: "Criar componente de coluna" }
+          ]
+        },
+        {
+          id: 2,
+          name: "Em Andamento",
+          cards: [{ id: 3, title: "Implementar CreateColumnModal" }]
+        },
+        {
+          id: 3,
+          name: "Concluído",
+          cards: [{ id: 4, title: "Exibir colunas mockadas" }]
+        }
+      ]
+    }
+  ];
+}


### PR DESCRIPTION
Este PR implementa a funcionalidade descrita na issue #4, permitindo que usuários criem, editem e excluam colunas personalizadas em seus quadros de tarefas.

Funcionalidades implementadas:

- Criação de colunas com nomes definidos pelo usuário através de modal
- Renomeação de colunas com interface de edição inline via modal
- Exclusão de colunas com confirmação em modal seguro
- Renderização imediata das alterações no board após criação, edição ou exclusão
- Manutenção do código com estrutura modular e reutilização de componentes

Closes #4 
